### PR TITLE
Added options to make logging / output more machine readable 

### DIFF
--- a/Mist.xcodeproj/project.pbxproj
+++ b/Mist.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		57D135AB25FED139003467B2 /* MistError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D135AA25FED139003467B2 /* MistError.swift */; };
 		57D135B825FEEE48003467B2 /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = 57D135B725FEEE48003467B2 /* Yams */; };
 		57F0F3CE2600907D00480DEE /* Int64+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F0F3CD2600907D00480DEE /* Int64+Extension.swift */; };
+		7621FE00278A7AB100C38FAF /* DownloadInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7621FDFF278A7AB100C38FAF /* DownloadInfo.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -79,6 +80,7 @@
 		57D1359925FE1364003467B2 /* Shell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shell.swift; sourceTree = "<group>"; };
 		57D135AA25FED139003467B2 /* MistError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MistError.swift; sourceTree = "<group>"; };
 		57F0F3CD2600907D00480DEE /* Int64+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int64+Extension.swift"; sourceTree = "<group>"; };
+		7621FDFF278A7AB100C38FAF /* DownloadInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DownloadInfo.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -176,6 +178,7 @@
 		5744142125F8675400DE5540 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				7621FDFF278A7AB100C38FAF /* DownloadInfo.swift */,
 				570D5090260034E10066E4C9 /* Catalog.swift */,
 				3967935B26D7304500DC2D2D /* Firmware.swift */,
 				57D135AA25FED139003467B2 /* MistError.swift */,
@@ -319,6 +322,7 @@
 				5744140925F8603300DE5540 /* Mist.swift in Sources */,
 				57F0F3CE2600907D00480DEE /* Int64+Extension.swift in Sources */,
 				57550FE625FF3D49006C29EE /* Download.swift in Sources */,
+				7621FE00278A7AB100C38FAF /* DownloadInfo.swift in Sources */,
 				57D1357B25F9F716003467B2 /* HTTP.swift in Sources */,
 				3967935526D7272100DC2D2D /* ListCommand.swift in Sources */,
 				570D5091260034E10066E4C9 /* Catalog.swift in Sources */,
@@ -459,7 +463,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = 7K3HVCLV7Z;
+				DEVELOPMENT_TEAM = UXP6YEHSPW;
 				ENABLE_HARDENED_RUNTIME = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ninxsoft.mist;
@@ -474,7 +478,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = 7K3HVCLV7Z;
+				DEVELOPMENT_TEAM = UXP6YEHSPW;
 				ENABLE_HARDENED_RUNTIME = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ninxsoft.mist;

--- a/Mist.xcodeproj/xcshareddata/xcschemes/Mist.xcscheme
+++ b/Mist.xcodeproj/xcshareddata/xcschemes/Mist.xcscheme
@@ -34,6 +34,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      debugAsWhichUser = "root"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -50,6 +51,12 @@
             ReferencedContainer = "container:Mist.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "download  -j -b -p intel --application  &quot;macOS Monterey&quot; "
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Mist.xcodeproj/xcshareddata/xcschemes/Mist.xcscheme
+++ b/Mist.xcodeproj/xcshareddata/xcschemes/Mist.xcscheme
@@ -34,7 +34,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      debugAsWhichUser = "root"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Mist.xcodeproj/xcshareddata/xcschemes/Mist.xcscheme
+++ b/Mist.xcodeproj/xcshareddata/xcschemes/Mist.xcscheme
@@ -51,12 +51,6 @@
             ReferencedContainer = "container:Mist.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-         <CommandLineArgument
-            argument = "download  -j -b -p intel --application  &quot;macOS Monterey&quot; "
-            isEnabled = "YES">
-         </CommandLineArgument>
-      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Mist/Commands/Download/Download.swift
+++ b/Mist/Commands/Download/Download.swift
@@ -18,17 +18,17 @@ struct Download {
     /// - Throws: A `MistError` if a macOS version fails to download.
     static func run(options: DownloadOptions) throws {
         try inputValidation(options)
-        PrettyPrint.printHeader("SEARCH", parsable: options.jsonOutput)
-        PrettyPrint.print("Searching for macOS download '\(options.searchString)'...", parsable: options.jsonOutput)
+        PrettyPrint.printHeader("SEARCH", structuredOutput: options.structuredOutput)
+        PrettyPrint.print("Searching for macOS download '\(options.searchString)'...", structuredOutput: options.structuredOutput)
 
         switch options.platform {
         case .apple:
             guard let firmware: Firmware = HTTP.firmware(from: HTTP.retrieveFirmwares(includeBetas: options.includeBetas), searchString: options.searchString) else {
-                PrettyPrint.print("No macOS Firmware found with '\(options.searchString)', exiting...", prefix: .ending, parsable: options.jsonOutput)
+                PrettyPrint.print("No macOS Firmware found with '\(options.searchString)', exiting...", prefix: .ending, structuredOutput: options.structuredOutput)
                 exit(-1)
             }
 
-            PrettyPrint.print("Found \(firmware.name) \(firmware.version) (\(firmware.build)) [\(firmware.dateDescription)]", parsable: options.jsonOutput)
+            PrettyPrint.print("Found \(firmware.name) \(firmware.version) (\(firmware.build)) [\(firmware.dateDescription)]", structuredOutput: options.structuredOutput)
             try verifyExistingFiles(firmware, options: options)
             try setup(firmware, options: options)
             try verifyFreeSpace(firmware, options: options)
@@ -45,11 +45,11 @@ struct Download {
             let retrievedProducts: [Product] = HTTP.retrieveProducts(from: catalogURLs, includeBetas: options.includeBetas)
 
             guard let product: Product = HTTP.product(from: retrievedProducts, searchString: options.searchString) else {
-                PrettyPrint.print("No macOS Installer found with '\(options.searchString)', exiting...", prefix: .ending, parsable: options.jsonOutput)
+                PrettyPrint.print("No macOS Installer found with '\(options.searchString)', exiting...", prefix: .ending, structuredOutput: options.structuredOutput)
                 exit(-1)
             }
 
-            PrettyPrint.print("Found [\(product.identifier)] \(product.name) \(product.version) (\(product.build)) [\(product.date)]", parsable: options.jsonOutput)
+            PrettyPrint.print("Found [\(product.identifier)] \(product.name) \(product.version) (\(product.build)) [\(product.date)]", structuredOutput: options.structuredOutput)
             try verifyExistingFiles(product, options: options)
             try setup(product, options: options)
             try verifyFreeSpace(product, options: options)
@@ -68,33 +68,33 @@ struct Download {
     /// - Throws: A `MistError` if any of the input validations fail.
     private static func inputValidation(_ options: DownloadOptions) throws {
 
-        PrettyPrint.printHeader("INPUT VALIDATION",parsable: options.jsonOutput)
+        PrettyPrint.printHeader("INPUT VALIDATION",structuredOutput: options.structuredOutput)
 
         guard NSUserName() == "root" else {
             throw MistError.invalidUser
         }
 
-        PrettyPrint.print("User is 'root'...", parsable: options.jsonOutput)
+        PrettyPrint.print("User is 'root'...", structuredOutput: options.structuredOutput)
 
         guard !options.searchString.isEmpty else {
             throw MistError.missingDownloadSearchString
         }
 
-        PrettyPrint.print("Download search string will be '\(options.searchString)'...", parsable: options.jsonOutput)
+        PrettyPrint.print("Download search string will be '\(options.searchString)'...", structuredOutput: options.structuredOutput)
 
         guard !options.outputDirectory.isEmpty else {
             throw MistError.missingOutputDirectory
         }
 
-        PrettyPrint.print("Platform will be '\(options.platform)'...", parsable: options.jsonOutput)
-        PrettyPrint.print("Include betas in search results will be '\(options.includeBetas)'...", parsable: options.jsonOutput)
-        PrettyPrint.print("Output directory will be '\(options.outputDirectory)'...", parsable: options.jsonOutput)
-        PrettyPrint.print("Temporary directory will be '\(options.temporaryDirectory)'...", parsable: options.jsonOutput)
+        PrettyPrint.print("Platform will be '\(options.platform)'...", structuredOutput: options.structuredOutput)
+        PrettyPrint.print("Include betas in search results will be '\(options.includeBetas)'...", structuredOutput: options.structuredOutput)
+        PrettyPrint.print("Output directory will be '\(options.outputDirectory)'...", structuredOutput: options.structuredOutput)
+        PrettyPrint.print("Temporary directory will be '\(options.temporaryDirectory)'...", structuredOutput: options.structuredOutput)
 
         if options.force {
-            PrettyPrint.print("Force flag set, existing files will be overwritten...", parsable: options.jsonOutput)
+            PrettyPrint.print("Force flag set, existing files will be overwritten...", structuredOutput: options.structuredOutput)
         } else {
-            PrettyPrint.print("Force flag has not been set, existing files will not be overwritten...", parsable: options.jsonOutput)
+            PrettyPrint.print("Force flag has not been set, existing files will not be overwritten...", structuredOutput: options.structuredOutput)
         }
 
         switch options.platform {
@@ -106,7 +106,7 @@ struct Download {
                 throw MistError.missingOutputType
             }
 
-            PrettyPrint.print("Valid download type(s) specified...", parsable: options.jsonOutput)
+            PrettyPrint.print("Valid download type(s) specified...", structuredOutput: options.structuredOutput)
             try inputValidationApplication(options)
             try inputValidationImage(options)
             try inputValidationPackage(options)
@@ -125,7 +125,7 @@ struct Download {
             throw MistError.missingFirmwareName
         }
 
-        PrettyPrint.print("Firmware name will be '\(options.firmwareName)'...", parsable: options.jsonOutput)
+        PrettyPrint.print("Firmware name will be '\(options.firmwareName)'...", structuredOutput: options.structuredOutput)
     }
 
     /// Performs a series of input validations specific to macOS Application output.
@@ -142,7 +142,7 @@ struct Download {
                 throw MistError.missingApplicationName
             }
 
-            PrettyPrint.print("Application name will be '\(options.applicationName)'...", parsable: options.jsonOutput)
+            PrettyPrint.print("Application name will be '\(options.applicationName)'...", structuredOutput: options.structuredOutput)
         }
     }
 
@@ -160,7 +160,7 @@ struct Download {
                 throw MistError.missingImageName
             }
 
-            PrettyPrint.print("Disk Image name will be '\(options.imageName)'...", parsable: options.jsonOutput)
+            PrettyPrint.print("Disk Image name will be '\(options.imageName)'...", structuredOutput: options.structuredOutput)
 
             if let identity: String = options.imageSigningIdentity {
 
@@ -168,7 +168,7 @@ struct Download {
                     throw MistError.missingImageSigningIdentity
                 }
 
-                PrettyPrint.print("Disk Image signing identity will be '\(identity)'...", parsable: options.jsonOutput)
+                PrettyPrint.print("Disk Image signing identity will be '\(identity)'...", structuredOutput: options.structuredOutput)
             }
         }
     }
@@ -187,14 +187,14 @@ struct Download {
                 throw MistError.missingPackageName
             }
 
-            PrettyPrint.print("Package name will be '\(options.packageName)'...", parsable: options.jsonOutput)
+            PrettyPrint.print("Package name will be '\(options.packageName)'...", structuredOutput: options.structuredOutput)
 
             guard let identifier: String = options.packageIdentifier,
                 !identifier.isEmpty else {
                 throw MistError.missingPackageIdentifier
             }
 
-            PrettyPrint.print("Package identifier will be '\(identifier)'...", parsable: options.jsonOutput)
+            PrettyPrint.print("Package identifier will be '\(identifier)'...", structuredOutput: options.structuredOutput)
 
             if let identity: String = options.packageSigningIdentity {
 
@@ -202,7 +202,7 @@ struct Download {
                     throw MistError.missingPackageSigningIdentity
                 }
 
-                PrettyPrint.print("Package signing identity will be '\(identity)'...", parsable: options.jsonOutput)
+                PrettyPrint.print("Package signing identity will be '\(identity)'...", structuredOutput: options.structuredOutput)
             }
         }
     }
@@ -277,19 +277,19 @@ struct Download {
         let outputURL: URL = URL(fileURLWithPath: options.outputDirectory(for: firmware))
         let temporaryURL: URL = URL(fileURLWithPath: options.temporaryDirectory(for: firmware))
 
-        PrettyPrint.printHeader("SETUP",parsable: options.jsonOutput)
+        PrettyPrint.printHeader("SETUP",structuredOutput: options.structuredOutput)
 
         if !FileManager.default.fileExists(atPath: outputURL.path) {
-            PrettyPrint.print("Creating output directory '\(outputURL.path)'...", parsable: options.jsonOutput)
+            PrettyPrint.print("Creating output directory '\(outputURL.path)'...", structuredOutput: options.structuredOutput)
             try FileManager.default.createDirectory(atPath: outputURL.path, withIntermediateDirectories: true, attributes: nil)
         }
 
         if FileManager.default.fileExists(atPath: temporaryURL.path) {
-            PrettyPrint.print("Deleting old temporary directory '\(temporaryURL.path)'...", parsable: options.jsonOutput)
+            PrettyPrint.print("Deleting old temporary directory '\(temporaryURL.path)'...", structuredOutput: options.structuredOutput)
             try FileManager.default.removeItem(at: temporaryURL)
         }
 
-        PrettyPrint.print("Creating new temporary directory '\(temporaryURL.path)'...", parsable: options.jsonOutput)
+        PrettyPrint.print("Creating new temporary directory '\(temporaryURL.path)'...", structuredOutput: options.structuredOutput)
         try FileManager.default.createDirectory(at: temporaryURL, withIntermediateDirectories: true, attributes: nil)
     }
 
@@ -305,19 +305,19 @@ struct Download {
         let outputURL: URL = URL(fileURLWithPath: options.outputDirectory(for: product))
         let temporaryURL: URL = URL(fileURLWithPath: options.temporaryDirectory(for: product))
 
-        PrettyPrint.printHeader("SETUP",parsable: options.jsonOutput)
+        PrettyPrint.printHeader("SETUP",structuredOutput: options.structuredOutput)
 
         if !FileManager.default.fileExists(atPath: outputURL.path) {
-            PrettyPrint.print("Creating output directory '\(outputURL.path)'...", parsable: options.jsonOutput)
+            PrettyPrint.print("Creating output directory '\(outputURL.path)'...", structuredOutput: options.structuredOutput)
             try FileManager.default.createDirectory(atPath: outputURL.path, withIntermediateDirectories: true, attributes: nil)
         }
 
         if FileManager.default.fileExists(atPath: temporaryURL.path) {
-            PrettyPrint.print("Deleting old temporary directory '\(temporaryURL.path)'...", parsable: options.jsonOutput)
+            PrettyPrint.print("Deleting old temporary directory '\(temporaryURL.path)'...", structuredOutput: options.structuredOutput)
             try FileManager.default.removeItem(at: temporaryURL)
         }
 
-        PrettyPrint.print("Creating new temporary directory '\(temporaryURL.path)'...", parsable: options.jsonOutput)
+        PrettyPrint.print("Creating new temporary directory '\(temporaryURL.path)'...", structuredOutput: options.structuredOutput)
         try FileManager.default.createDirectory(at: temporaryURL, withIntermediateDirectories: true, attributes: nil)
     }
 
@@ -424,8 +424,8 @@ struct Download {
         let temporaryURL: URL = URL(fileURLWithPath: options.temporaryDirectory(for: firmware))
 
         if FileManager.default.fileExists(atPath: temporaryURL.path) {
-            PrettyPrint.printHeader("TEARDOWN",parsable: options.jsonOutput)
-            PrettyPrint.print("Deleting temporary directory '\(temporaryURL.path)'...", prefix: .ending, parsable: options.jsonOutput)
+            PrettyPrint.printHeader("TEARDOWN",structuredOutput: options.structuredOutput)
+            PrettyPrint.print("Deleting temporary directory '\(temporaryURL.path)'...", prefix: .ending, structuredOutput: options.structuredOutput)
             try FileManager.default.removeItem(at: temporaryURL)
         }
     }
@@ -438,8 +438,8 @@ struct Download {
     ///
     /// - Throws: An `Error` if any of the directory operations fail.
     private static func teardown(_ product: Product, options: DownloadOptions) throws {
-        PrettyPrint.printHeader("TEARDOWN",parsable: options.jsonOutput)
-        PrettyPrint.print("Deleting installer '\(product.installerURL.path)'...", prefix: .ending, parsable: options.jsonOutput)
+        PrettyPrint.printHeader("TEARDOWN",structuredOutput: options.structuredOutput)
+        PrettyPrint.print("Deleting installer '\(product.installerURL.path)'...", prefix: .ending, structuredOutput: options.structuredOutput)
         try FileManager.default.removeItem(at: product.installerURL)
     }
 }

--- a/Mist/Commands/Download/Download.swift
+++ b/Mist/Commands/Download/Download.swift
@@ -18,17 +18,17 @@ struct Download {
     /// - Throws: A `MistError` if a macOS version fails to download.
     static func run(options: DownloadOptions) throws {
         try inputValidation(options)
-        PrettyPrint.printHeader("SEARCH")
-        PrettyPrint.print("Searching for macOS download '\(options.searchString)'...")
+        PrettyPrint.printHeader("SEARCH", parsable: options.jsonOutput)
+        PrettyPrint.print("Searching for macOS download '\(options.searchString)'...", parsable: options.jsonOutput)
 
         switch options.platform {
         case .apple:
             guard let firmware: Firmware = HTTP.firmware(from: HTTP.retrieveFirmwares(includeBetas: options.includeBetas), searchString: options.searchString) else {
-                PrettyPrint.print("No macOS Firmware found with '\(options.searchString)', exiting...", prefix: .ending)
-                return
+                PrettyPrint.print("No macOS Firmware found with '\(options.searchString)', exiting...", prefix: .ending, parsable: options.jsonOutput)
+                exit(-1)
             }
 
-            PrettyPrint.print("Found \(firmware.name) \(firmware.version) (\(firmware.build)) [\(firmware.dateDescription)]")
+            PrettyPrint.print("Found \(firmware.name) \(firmware.version) (\(firmware.build)) [\(firmware.dateDescription)]", parsable: options.jsonOutput)
             try verifyExistingFiles(firmware, options: options)
             try setup(firmware, options: options)
             try verifyFreeSpace(firmware, options: options)
@@ -45,11 +45,11 @@ struct Download {
             let retrievedProducts: [Product] = HTTP.retrieveProducts(from: catalogURLs, includeBetas: options.includeBetas)
 
             guard let product: Product = HTTP.product(from: retrievedProducts, searchString: options.searchString) else {
-                PrettyPrint.print("No macOS Installer found with '\(options.searchString)', exiting...", prefix: .ending)
-                return
+                PrettyPrint.print("No macOS Installer found with '\(options.searchString)', exiting...", prefix: .ending, parsable: options.jsonOutput)
+                exit(-1)
             }
 
-            PrettyPrint.print("Found [\(product.identifier)] \(product.name) \(product.version) (\(product.build)) [\(product.date)]")
+            PrettyPrint.print("Found [\(product.identifier)] \(product.name) \(product.version) (\(product.build)) [\(product.date)]", parsable: options.jsonOutput)
             try verifyExistingFiles(product, options: options)
             try setup(product, options: options)
             try verifyFreeSpace(product, options: options)
@@ -68,33 +68,33 @@ struct Download {
     /// - Throws: A `MistError` if any of the input validations fail.
     private static func inputValidation(_ options: DownloadOptions) throws {
 
-        PrettyPrint.printHeader("INPUT VALIDATION")
+        PrettyPrint.printHeader("INPUT VALIDATION",parsable: options.jsonOutput)
 
         guard NSUserName() == "root" else {
             throw MistError.invalidUser
         }
 
-        PrettyPrint.print("User is 'root'...")
+        PrettyPrint.print("User is 'root'...", parsable: options.jsonOutput)
 
         guard !options.searchString.isEmpty else {
             throw MistError.missingDownloadSearchString
         }
 
-        PrettyPrint.print("Download search string will be '\(options.searchString)'...")
+        PrettyPrint.print("Download search string will be '\(options.searchString)'...", parsable: options.jsonOutput)
 
         guard !options.outputDirectory.isEmpty else {
             throw MistError.missingOutputDirectory
         }
 
-        PrettyPrint.print("Platform will be '\(options.platform)'...")
-        PrettyPrint.print("Include betas in search results will be '\(options.includeBetas)'...")
-        PrettyPrint.print("Output directory will be '\(options.outputDirectory)'...")
-        PrettyPrint.print("Temporary directory will be '\(options.temporaryDirectory)'...")
+        PrettyPrint.print("Platform will be '\(options.platform)'...", parsable: options.jsonOutput)
+        PrettyPrint.print("Include betas in search results will be '\(options.includeBetas)'...", parsable: options.jsonOutput)
+        PrettyPrint.print("Output directory will be '\(options.outputDirectory)'...", parsable: options.jsonOutput)
+        PrettyPrint.print("Temporary directory will be '\(options.temporaryDirectory)'...", parsable: options.jsonOutput)
 
         if options.force {
-            PrettyPrint.print("Force flag set, existing files will be overwritten...")
+            PrettyPrint.print("Force flag set, existing files will be overwritten...", parsable: options.jsonOutput)
         } else {
-            PrettyPrint.print("Force flag has not been set, existing files will not be overwritten...")
+            PrettyPrint.print("Force flag has not been set, existing files will not be overwritten...", parsable: options.jsonOutput)
         }
 
         switch options.platform {
@@ -106,7 +106,7 @@ struct Download {
                 throw MistError.missingOutputType
             }
 
-            PrettyPrint.print("Valid download type(s) specified...")
+            PrettyPrint.print("Valid download type(s) specified...", parsable: options.jsonOutput)
             try inputValidationApplication(options)
             try inputValidationImage(options)
             try inputValidationPackage(options)
@@ -125,7 +125,7 @@ struct Download {
             throw MistError.missingFirmwareName
         }
 
-        PrettyPrint.print("Firmware name will be '\(options.firmwareName)'...")
+        PrettyPrint.print("Firmware name will be '\(options.firmwareName)'...", parsable: options.jsonOutput)
     }
 
     /// Performs a series of input validations specific to macOS Application output.
@@ -142,7 +142,7 @@ struct Download {
                 throw MistError.missingApplicationName
             }
 
-            PrettyPrint.print("Application name will be '\(options.applicationName)'...")
+            PrettyPrint.print("Application name will be '\(options.applicationName)'...", parsable: options.jsonOutput)
         }
     }
 
@@ -160,7 +160,7 @@ struct Download {
                 throw MistError.missingImageName
             }
 
-            PrettyPrint.print("Disk Image name will be '\(options.imageName)'...")
+            PrettyPrint.print("Disk Image name will be '\(options.imageName)'...", parsable: options.jsonOutput)
 
             if let identity: String = options.imageSigningIdentity {
 
@@ -168,7 +168,7 @@ struct Download {
                     throw MistError.missingImageSigningIdentity
                 }
 
-                PrettyPrint.print("Disk Image signing identity will be '\(identity)'...")
+                PrettyPrint.print("Disk Image signing identity will be '\(identity)'...", parsable: options.jsonOutput)
             }
         }
     }
@@ -187,14 +187,14 @@ struct Download {
                 throw MistError.missingPackageName
             }
 
-            PrettyPrint.print("Package name will be '\(options.packageName)'...")
+            PrettyPrint.print("Package name will be '\(options.packageName)'...", parsable: options.jsonOutput)
 
             guard let identifier: String = options.packageIdentifier,
                 !identifier.isEmpty else {
                 throw MistError.missingPackageIdentifier
             }
 
-            PrettyPrint.print("Package identifier will be '\(identifier)'...")
+            PrettyPrint.print("Package identifier will be '\(identifier)'...", parsable: options.jsonOutput)
 
             if let identity: String = options.packageSigningIdentity {
 
@@ -202,7 +202,7 @@ struct Download {
                     throw MistError.missingPackageSigningIdentity
                 }
 
-                PrettyPrint.print("Package signing identity will be '\(identity)'...")
+                PrettyPrint.print("Package signing identity will be '\(identity)'...", parsable: options.jsonOutput)
             }
         }
     }
@@ -277,19 +277,19 @@ struct Download {
         let outputURL: URL = URL(fileURLWithPath: options.outputDirectory(for: firmware))
         let temporaryURL: URL = URL(fileURLWithPath: options.temporaryDirectory(for: firmware))
 
-        PrettyPrint.printHeader("SETUP")
+        PrettyPrint.printHeader("SETUP",parsable: options.jsonOutput)
 
         if !FileManager.default.fileExists(atPath: outputURL.path) {
-            PrettyPrint.print("Creating output directory '\(outputURL.path)'...")
+            PrettyPrint.print("Creating output directory '\(outputURL.path)'...", parsable: options.jsonOutput)
             try FileManager.default.createDirectory(atPath: outputURL.path, withIntermediateDirectories: true, attributes: nil)
         }
 
         if FileManager.default.fileExists(atPath: temporaryURL.path) {
-            PrettyPrint.print("Deleting old temporary directory '\(temporaryURL.path)'...")
+            PrettyPrint.print("Deleting old temporary directory '\(temporaryURL.path)'...", parsable: options.jsonOutput)
             try FileManager.default.removeItem(at: temporaryURL)
         }
 
-        PrettyPrint.print("Creating new temporary directory '\(temporaryURL.path)'...")
+        PrettyPrint.print("Creating new temporary directory '\(temporaryURL.path)'...", parsable: options.jsonOutput)
         try FileManager.default.createDirectory(at: temporaryURL, withIntermediateDirectories: true, attributes: nil)
     }
 
@@ -305,19 +305,19 @@ struct Download {
         let outputURL: URL = URL(fileURLWithPath: options.outputDirectory(for: product))
         let temporaryURL: URL = URL(fileURLWithPath: options.temporaryDirectory(for: product))
 
-        PrettyPrint.printHeader("SETUP")
+        PrettyPrint.printHeader("SETUP",parsable: options.jsonOutput)
 
         if !FileManager.default.fileExists(atPath: outputURL.path) {
-            PrettyPrint.print("Creating output directory '\(outputURL.path)'...")
+            PrettyPrint.print("Creating output directory '\(outputURL.path)'...", parsable: options.jsonOutput)
             try FileManager.default.createDirectory(atPath: outputURL.path, withIntermediateDirectories: true, attributes: nil)
         }
 
         if FileManager.default.fileExists(atPath: temporaryURL.path) {
-            PrettyPrint.print("Deleting old temporary directory '\(temporaryURL.path)'...")
+            PrettyPrint.print("Deleting old temporary directory '\(temporaryURL.path)'...", parsable: options.jsonOutput)
             try FileManager.default.removeItem(at: temporaryURL)
         }
 
-        PrettyPrint.print("Creating new temporary directory '\(temporaryURL.path)'...")
+        PrettyPrint.print("Creating new temporary directory '\(temporaryURL.path)'...", parsable: options.jsonOutput)
         try FileManager.default.createDirectory(at: temporaryURL, withIntermediateDirectories: true, attributes: nil)
     }
 
@@ -424,8 +424,8 @@ struct Download {
         let temporaryURL: URL = URL(fileURLWithPath: options.temporaryDirectory(for: firmware))
 
         if FileManager.default.fileExists(atPath: temporaryURL.path) {
-            PrettyPrint.printHeader("TEARDOWN")
-            PrettyPrint.print("Deleting temporary directory '\(temporaryURL.path)'...", prefix: .ending)
+            PrettyPrint.printHeader("TEARDOWN",parsable: options.jsonOutput)
+            PrettyPrint.print("Deleting temporary directory '\(temporaryURL.path)'...", prefix: .ending, parsable: options.jsonOutput)
             try FileManager.default.removeItem(at: temporaryURL)
         }
     }
@@ -438,8 +438,8 @@ struct Download {
     ///
     /// - Throws: An `Error` if any of the directory operations fail.
     private static func teardown(_ product: Product, options: DownloadOptions) throws {
-        PrettyPrint.printHeader("TEARDOWN")
-        PrettyPrint.print("Deleting installer '\(product.installerURL.path)'...", prefix: .ending)
+        PrettyPrint.printHeader("TEARDOWN",parsable: options.jsonOutput)
+        PrettyPrint.print("Deleting installer '\(product.installerURL.path)'...", prefix: .ending, parsable: options.jsonOutput)
         try FileManager.default.removeItem(at: product.installerURL)
     }
 }

--- a/Mist/Commands/Download/DownloadCommand.swift
+++ b/Mist/Commands/Download/DownloadCommand.swift
@@ -21,7 +21,7 @@ struct DownloadCommand: ParsableCommand {
                 throw error
             }
 
-            PrettyPrint.print(mistError.description, prefix: .ending, prefixColor: .red, parsable: options.jsonOutput)
+            PrettyPrint.print(mistError.description, prefix: .ending, prefixColor: .red, structuredOutput: options.structuredOutput)
             throw mistError
         }
     }

--- a/Mist/Commands/Download/DownloadCommand.swift
+++ b/Mist/Commands/Download/DownloadCommand.swift
@@ -21,7 +21,7 @@ struct DownloadCommand: ParsableCommand {
                 throw error
             }
 
-            PrettyPrint.print(mistError.description, prefix: .ending, prefixColor: .red)
+            PrettyPrint.print(mistError.description, prefix: .ending, prefixColor: .red, parsable: options.jsonOutput)
             throw mistError
         }
     }

--- a/Mist/Commands/Download/DownloadOptions.swift
+++ b/Mist/Commands/Download/DownloadOptions.swift
@@ -44,6 +44,11 @@ struct DownloadOptions: ParsableArguments {
     """)
     var includeBetas: Bool = false
 
+    @Flag(name: [.customShort("j"), .long], help: """
+    Output status in json format for easy parsing.
+    """)
+    var jsonOutput: Bool = false
+
     @Option(name: .shortAndLong, help: """
     Override the default Software Update Catalog URLs.
     Note: This only applies when the platform is set to 'intel'.

--- a/Mist/Commands/Download/DownloadOptions.swift
+++ b/Mist/Commands/Download/DownloadOptions.swift
@@ -47,7 +47,7 @@ struct DownloadOptions: ParsableArguments {
     @Flag(name: [.customShort("j"), .long], help: """
     Output status in json format for easy parsing.
     """)
-    var jsonOutput: Bool = false
+    var structuredOutput: Bool = false
 
     @Option(name: .shortAndLong, help: """
     Override the default Software Update Catalog URLs.

--- a/Mist/Commands/List/List.swift
+++ b/Mist/Commands/List/List.swift
@@ -20,11 +20,11 @@ struct List {
     static func run(options: ListOptions) throws {
         try inputValidation(options)
 
-        !options.quiet ? PrettyPrint.printHeader("SEARCH", parsable: false) : Mist.noop()
+        !options.quiet ? PrettyPrint.printHeader("SEARCH", structuredOutput: false) : Mist.noop()
 
         switch options.platform {
         case .apple:
-            !options.quiet ? PrettyPrint.print("Searching for macOS Firmware versions...", parsable: false) : Mist.noop()
+            !options.quiet ? PrettyPrint.print("Searching for macOS Firmware versions...", structuredOutput: false) : Mist.noop()
 
             var firmwares: [Firmware] = HTTP.retrieveFirmwares(includeBetas: options.includeBetas, quiet: options.quiet)
 
@@ -39,11 +39,11 @@ struct List {
             }
 
             try export(firmwares.map { $0.dictionary }, options: options)
-            !options.quiet ? PrettyPrint.print("Found \(firmwares.count) macOS Firmware(s) available for download\n", prefix: .ending, parsable: false) : Mist.noop()
+            !options.quiet ? PrettyPrint.print("Found \(firmwares.count) macOS Firmware(s) available for download\n", prefix: .ending, structuredOutput: false) : Mist.noop()
             try list(firmwares.map { $0.dictionary }, options: options)
 
         case .intel:
-            !options.quiet ? PrettyPrint.print("Searching for macOS Installer versions...", parsable: false) : Mist.noop()
+            !options.quiet ? PrettyPrint.print("Searching for macOS Installer versions...", structuredOutput: false) : Mist.noop()
 
             var catalogURLs: [String] = Catalog.urls
 
@@ -64,7 +64,7 @@ struct List {
             }
 
             try export(products.map { $0.dictionary }, options: options)
-            !options.quiet ? PrettyPrint.print("Found \(products.count) macOS Installer(s) available for download\n", prefix: .ending, parsable: false) : Mist.noop()
+            !options.quiet ? PrettyPrint.print("Found \(products.count) macOS Installer(s) available for download\n", prefix: .ending, structuredOutput: false) : Mist.noop()
             try list(products.map { $0.dictionary }, options: options)
         }
     }
@@ -77,8 +77,8 @@ struct List {
     /// - Throws: A `MistError` if any of the input validations fail.
     private static func inputValidation(_ options: ListOptions) throws {
 
-        !options.quiet ? PrettyPrint.printHeader("INPUT VALIDATION", parsable: false) : Mist.noop()
-        !options.quiet ? PrettyPrint.print("Platform will be '\(options.platform)'...", parsable: false) : Mist.noop()
+        !options.quiet ? PrettyPrint.printHeader("INPUT VALIDATION", structuredOutput: false) : Mist.noop()
+        !options.quiet ? PrettyPrint.print("Platform will be '\(options.platform)'...", structuredOutput: false) : Mist.noop()
 
         if let string: String = options.searchString {
 
@@ -86,14 +86,14 @@ struct List {
                 throw MistError.missingListSearchString
             }
 
-            !options.quiet ? PrettyPrint.print("List search string will be '\(string)'...", parsable: false) : Mist.noop()
+            !options.quiet ? PrettyPrint.print("List search string will be '\(string)'...", structuredOutput: false) : Mist.noop()
         }
 
         if options.latest {
-            !options.quiet ? PrettyPrint.print("Searching only for latest (first) result...", parsable: false) : Mist.noop()
+            !options.quiet ? PrettyPrint.print("Searching only for latest (first) result...", structuredOutput: false) : Mist.noop()
         }
 
-        !options.quiet ? PrettyPrint.print("Include betas in search results will be '\(options.includeBetas)'...", parsable: false) : Mist.noop()
+        !options.quiet ? PrettyPrint.print("Include betas in search results will be '\(options.includeBetas)'...", structuredOutput: false) : Mist.noop()
 
         if let path: String = options.exportPath {
 
@@ -101,7 +101,7 @@ struct List {
                 throw MistError.missingExportPath
             }
 
-            !options.quiet ? PrettyPrint.print("Export path will be '\(path)'...", parsable: false) : Mist.noop()
+            !options.quiet ? PrettyPrint.print("Export path will be '\(path)'...", structuredOutput: false) : Mist.noop()
 
             let url: URL = URL(fileURLWithPath: path)
 
@@ -109,10 +109,10 @@ struct List {
                 throw MistError.invalidExportFileExtension
             }
 
-            !options.quiet ? PrettyPrint.print("Export path file extension is valid...", parsable: false) : Mist.noop()
+            !options.quiet ? PrettyPrint.print("Export path file extension is valid...", structuredOutput: false) : Mist.noop()
         }
 
-        !options.quiet ? PrettyPrint.print("Output type will be '\(options.outputType)'...", parsable: false) : Mist.noop()
+        !options.quiet ? PrettyPrint.print("Output type will be '\(options.outputType)'...", structuredOutput: false) : Mist.noop()
     }
 
     /// Export the macOS downloads list.
@@ -132,7 +132,7 @@ struct List {
         let directory: URL = url.deletingLastPathComponent()
 
         if !FileManager.default.fileExists(atPath: directory.path) {
-            !options.quiet ? PrettyPrint.print("Creating parent directory '\(directory.path)'...", parsable: false) : Mist.noop()
+            !options.quiet ? PrettyPrint.print("Creating parent directory '\(directory.path)'...", structuredOutput: false) : Mist.noop()
             try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
         }
 
@@ -145,16 +145,16 @@ struct List {
                 try dictionaries.productsCSVString().write(toFile: path, atomically: true, encoding: .utf8)
             }
 
-            !options.quiet ? PrettyPrint.print("Exported list as CSV: '\(path)'", parsable: false) : Mist.noop()
+            !options.quiet ? PrettyPrint.print("Exported list as CSV: '\(path)'", structuredOutput: false) : Mist.noop()
         case "json":
             try dictionaries.jsonString().write(toFile: path, atomically: true, encoding: .utf8)
-            !options.quiet ? PrettyPrint.print("Exported list as JSON: '\(path)'", parsable: false) : Mist.noop()
+            !options.quiet ? PrettyPrint.print("Exported list as JSON: '\(path)'", structuredOutput: false) : Mist.noop()
         case "plist":
             try dictionaries.propertyListString().write(toFile: path, atomically: true, encoding: .utf8)
-            !options.quiet ? PrettyPrint.print("Exported list as Property List: '\(path)'", parsable: false) : Mist.noop()
+            !options.quiet ? PrettyPrint.print("Exported list as Property List: '\(path)'", structuredOutput: false) : Mist.noop()
         case "yaml":
             try dictionaries.yamlString().write(toFile: path, atomically: true, encoding: .utf8)
-            !options.quiet ? PrettyPrint.print("Exported list as YAML: '\(path)'", parsable: false) : Mist.noop()
+            !options.quiet ? PrettyPrint.print("Exported list as YAML: '\(path)'", structuredOutput: false) : Mist.noop()
         default:
             break
         }

--- a/Mist/Commands/List/List.swift
+++ b/Mist/Commands/List/List.swift
@@ -20,11 +20,11 @@ struct List {
     static func run(options: ListOptions) throws {
         try inputValidation(options)
 
-        !options.quiet ? PrettyPrint.printHeader("SEARCH") : Mist.noop()
+        !options.quiet ? PrettyPrint.printHeader("SEARCH", parsable: false) : Mist.noop()
 
         switch options.platform {
         case .apple:
-            !options.quiet ? PrettyPrint.print("Searching for macOS Firmware versions...") : Mist.noop()
+            !options.quiet ? PrettyPrint.print("Searching for macOS Firmware versions...", parsable: false) : Mist.noop()
 
             var firmwares: [Firmware] = HTTP.retrieveFirmwares(includeBetas: options.includeBetas, quiet: options.quiet)
 
@@ -39,11 +39,11 @@ struct List {
             }
 
             try export(firmwares.map { $0.dictionary }, options: options)
-            !options.quiet ? PrettyPrint.print("Found \(firmwares.count) macOS Firmware(s) available for download\n", prefix: .ending) : Mist.noop()
+            !options.quiet ? PrettyPrint.print("Found \(firmwares.count) macOS Firmware(s) available for download\n", prefix: .ending, parsable: false) : Mist.noop()
             try list(firmwares.map { $0.dictionary }, options: options)
 
         case .intel:
-            !options.quiet ? PrettyPrint.print("Searching for macOS Installer versions...") : Mist.noop()
+            !options.quiet ? PrettyPrint.print("Searching for macOS Installer versions...", parsable: false) : Mist.noop()
 
             var catalogURLs: [String] = Catalog.urls
 
@@ -64,7 +64,7 @@ struct List {
             }
 
             try export(products.map { $0.dictionary }, options: options)
-            !options.quiet ? PrettyPrint.print("Found \(products.count) macOS Installer(s) available for download\n", prefix: .ending) : Mist.noop()
+            !options.quiet ? PrettyPrint.print("Found \(products.count) macOS Installer(s) available for download\n", prefix: .ending, parsable: false) : Mist.noop()
             try list(products.map { $0.dictionary }, options: options)
         }
     }
@@ -77,8 +77,8 @@ struct List {
     /// - Throws: A `MistError` if any of the input validations fail.
     private static func inputValidation(_ options: ListOptions) throws {
 
-        !options.quiet ? PrettyPrint.printHeader("INPUT VALIDATION") : Mist.noop()
-        !options.quiet ? PrettyPrint.print("Platform will be '\(options.platform)'...") : Mist.noop()
+        !options.quiet ? PrettyPrint.printHeader("INPUT VALIDATION", parsable: false) : Mist.noop()
+        !options.quiet ? PrettyPrint.print("Platform will be '\(options.platform)'...", parsable: false) : Mist.noop()
 
         if let string: String = options.searchString {
 
@@ -86,14 +86,14 @@ struct List {
                 throw MistError.missingListSearchString
             }
 
-            !options.quiet ? PrettyPrint.print("List search string will be '\(string)'...") : Mist.noop()
+            !options.quiet ? PrettyPrint.print("List search string will be '\(string)'...", parsable: false) : Mist.noop()
         }
 
         if options.latest {
-            !options.quiet ? PrettyPrint.print("Searching only for latest (first) result...") : Mist.noop()
+            !options.quiet ? PrettyPrint.print("Searching only for latest (first) result...", parsable: false) : Mist.noop()
         }
 
-        !options.quiet ? PrettyPrint.print("Include betas in search results will be '\(options.includeBetas)'...") : Mist.noop()
+        !options.quiet ? PrettyPrint.print("Include betas in search results will be '\(options.includeBetas)'...", parsable: false) : Mist.noop()
 
         if let path: String = options.exportPath {
 
@@ -101,7 +101,7 @@ struct List {
                 throw MistError.missingExportPath
             }
 
-            !options.quiet ? PrettyPrint.print("Export path will be '\(path)'...") : Mist.noop()
+            !options.quiet ? PrettyPrint.print("Export path will be '\(path)'...", parsable: false) : Mist.noop()
 
             let url: URL = URL(fileURLWithPath: path)
 
@@ -109,10 +109,10 @@ struct List {
                 throw MistError.invalidExportFileExtension
             }
 
-            !options.quiet ? PrettyPrint.print("Export path file extension is valid...") : Mist.noop()
+            !options.quiet ? PrettyPrint.print("Export path file extension is valid...", parsable: false) : Mist.noop()
         }
 
-        !options.quiet ? PrettyPrint.print("Output type will be '\(options.outputType)'...") : Mist.noop()
+        !options.quiet ? PrettyPrint.print("Output type will be '\(options.outputType)'...", parsable: false) : Mist.noop()
     }
 
     /// Export the macOS downloads list.
@@ -132,7 +132,7 @@ struct List {
         let directory: URL = url.deletingLastPathComponent()
 
         if !FileManager.default.fileExists(atPath: directory.path) {
-            !options.quiet ? PrettyPrint.print("Creating parent directory '\(directory.path)'...") : Mist.noop()
+            !options.quiet ? PrettyPrint.print("Creating parent directory '\(directory.path)'...", parsable: false) : Mist.noop()
             try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
         }
 
@@ -145,16 +145,16 @@ struct List {
                 try dictionaries.productsCSVString().write(toFile: path, atomically: true, encoding: .utf8)
             }
 
-            !options.quiet ? PrettyPrint.print("Exported list as CSV: '\(path)'") : Mist.noop()
+            !options.quiet ? PrettyPrint.print("Exported list as CSV: '\(path)'", parsable: false) : Mist.noop()
         case "json":
             try dictionaries.jsonString().write(toFile: path, atomically: true, encoding: .utf8)
-            !options.quiet ? PrettyPrint.print("Exported list as JSON: '\(path)'") : Mist.noop()
+            !options.quiet ? PrettyPrint.print("Exported list as JSON: '\(path)'", parsable: false) : Mist.noop()
         case "plist":
             try dictionaries.propertyListString().write(toFile: path, atomically: true, encoding: .utf8)
-            !options.quiet ? PrettyPrint.print("Exported list as Property List: '\(path)'") : Mist.noop()
+            !options.quiet ? PrettyPrint.print("Exported list as Property List: '\(path)'", parsable: false) : Mist.noop()
         case "yaml":
             try dictionaries.yamlString().write(toFile: path, atomically: true, encoding: .utf8)
-            !options.quiet ? PrettyPrint.print("Exported list as YAML: '\(path)'") : Mist.noop()
+            !options.quiet ? PrettyPrint.print("Exported list as YAML: '\(path)'", parsable: false) : Mist.noop()
         default:
             break
         }

--- a/Mist/Commands/List/ListCommand.swift
+++ b/Mist/Commands/List/ListCommand.swift
@@ -21,7 +21,7 @@ struct ListCommand: ParsableCommand {
                 throw error
             }
 
-            PrettyPrint.print(mistError.description, prefix: .ending, prefixColor: .red)
+            PrettyPrint.print(mistError.description, prefix: .ending, prefixColor: .red, parsable: false)
             throw mistError
         }
     }

--- a/Mist/Commands/List/ListCommand.swift
+++ b/Mist/Commands/List/ListCommand.swift
@@ -21,7 +21,7 @@ struct ListCommand: ParsableCommand {
                 throw error
             }
 
-            PrettyPrint.print(mistError.description, prefix: .ending, prefixColor: .red, parsable: false)
+            PrettyPrint.print(mistError.description, prefix: .ending, prefixColor: .red, structuredOutput: false)
             throw mistError
         }
     }

--- a/Mist/Helpers/Generator.swift
+++ b/Mist/Helpers/Generator.swift
@@ -30,7 +30,7 @@ struct Generator {
     /// - Throws: A `MistError` if the macOS Firmware fails to generate.
     private static func generateFirmware(firmware: Firmware, options: DownloadOptions) throws {
 
-        PrettyPrint.printHeader("FIRMWARE")
+        PrettyPrint.printHeader("FIRMWARE",parsable: options.jsonOutput)
         let temporaryURL: URL = URL(fileURLWithPath: options.temporaryDirectory(for: firmware))
 
         guard let firmwareURL: URL = URL(string: firmware.url) else {
@@ -40,7 +40,7 @@ struct Generator {
         let temporaryFirmwareURL: URL = temporaryURL.appendingPathComponent(firmwareURL.lastPathComponent)
         let destinationURL: URL = URL(fileURLWithPath: options.firmwarePath(for: firmware))
 
-        PrettyPrint.print("Validating Shasum matches \(firmware.shasum)...")
+        PrettyPrint.print("Validating Shasum matches \(firmware.shasum)...", parsable: options.jsonOutput)
 
         guard let string: String = try Shell.execute(["shasum", temporaryFirmwareURL.path]),
             let shasum: String = string.split(separator: " ").map({ String($0) }).first else {
@@ -59,11 +59,11 @@ struct Generator {
         }
 
         if FileManager.default.fileExists(atPath: destinationURL.path) {
-            PrettyPrint.print("Deleting old firmware '\(destinationURL.path)'...")
+            PrettyPrint.print("Deleting old firmware '\(destinationURL.path)'...", parsable: options.jsonOutput)
             try FileManager.default.removeItem(at: destinationURL)
         }
 
-        PrettyPrint.print("Moving '\(temporaryFirmwareURL.path)' to '\(destinationURL.path)'...")
+        PrettyPrint.print("Moving '\(temporaryFirmwareURL.path)' to '\(destinationURL.path)'...", parsable: options.jsonOutput)
         try FileManager.default.moveItem(at: temporaryFirmwareURL, to: destinationURL)
     }
 
@@ -98,7 +98,7 @@ struct Generator {
     /// - Throws: A `MistError` if the Application Bundle fails to generate.
     private static func generateApplication(product: Product, options: DownloadOptions) throws {
 
-        PrettyPrint.printHeader("APPLICATION")
+        PrettyPrint.printHeader("APPLICATION",parsable: options.jsonOutput)
         let destinationURL: URL = URL(fileURLWithPath: options.applicationPath(for: product))
 
         if !options.force {
@@ -109,11 +109,11 @@ struct Generator {
         }
 
         if FileManager.default.fileExists(atPath: destinationURL.path) {
-            PrettyPrint.print("Deleting old application '\(destinationURL.path)'...")
+            PrettyPrint.print("Deleting old application '\(destinationURL.path)'...", parsable: options.jsonOutput)
             try FileManager.default.removeItem(at: destinationURL)
         }
 
-        PrettyPrint.print("Copying '\(product.installerURL.path)' to '\(destinationURL.path)'...")
+        PrettyPrint.print("Copying '\(product.installerURL.path)' to '\(destinationURL.path)'...", parsable: options.jsonOutput)
         try FileManager.default.copyItem(at: product.installerURL, to: destinationURL)
     }
 
@@ -126,20 +126,20 @@ struct Generator {
     /// - Throws: A `MistError` if the macOS Installer Disk Image fails to generate.
     private static func generateImage(product: Product, options: DownloadOptions) throws {
 
-        PrettyPrint.printHeader("DISK IMAGE")
+        PrettyPrint.printHeader("DISK IMAGE",parsable: options.jsonOutput)
         let temporaryURL: URL = URL(fileURLWithPath: options.temporaryDirectory(for: product))
         let temporaryApplicationURL: URL = temporaryURL.appendingPathComponent("Install \(product.name).app")
         let destinationURL: URL = URL(fileURLWithPath: options.imagePath(for: product))
 
         if FileManager.default.fileExists(atPath: temporaryURL.path) {
-            PrettyPrint.print("Deleting old temporary directory '\(temporaryURL.path)'...")
+            PrettyPrint.print("Deleting old temporary directory '\(temporaryURL.path)'...", parsable: options.jsonOutput)
             try FileManager.default.removeItem(at: temporaryURL)
         }
 
-        PrettyPrint.print("Creating new temporary directory '\(temporaryURL.path)'...")
+        PrettyPrint.print("Creating new temporary directory '\(temporaryURL.path)'...", parsable: options.jsonOutput)
         try FileManager.default.createDirectory(at: temporaryURL, withIntermediateDirectories: true, attributes: nil)
 
-        PrettyPrint.print("Copying '\(product.installerURL.path)' to '\(temporaryApplicationURL.path)'...")
+        PrettyPrint.print("Copying '\(product.installerURL.path)' to '\(temporaryApplicationURL.path)'...", parsable: options.jsonOutput)
         try FileManager.default.copyItem(at: product.installerURL, to: temporaryApplicationURL)
 
         if !options.force {
@@ -150,11 +150,11 @@ struct Generator {
         }
 
         if FileManager.default.fileExists(atPath: destinationURL.path) {
-            PrettyPrint.print("Deleting old image '\(destinationURL.path)'...")
+            PrettyPrint.print("Deleting old image '\(destinationURL.path)'...", parsable: options.jsonOutput)
             try FileManager.default.removeItem(at: destinationURL)
         }
 
-        PrettyPrint.print("Creating image '\(destinationURL.path)'...")
+        PrettyPrint.print("Creating image '\(destinationURL.path)'...", parsable: options.jsonOutput)
         let arguments: [String] = ["hdiutil", "create", "-fs", "HFS+", "-srcFolder", temporaryURL.path, "-volname", "Install \(product.name)", destinationURL.path]
         _ = try Shell.execute(arguments)
 
@@ -170,14 +170,14 @@ struct Generator {
 
             arguments += [destinationURL.path]
 
-            PrettyPrint.print("Codesigning image '\(destinationURL.path)'...")
+            PrettyPrint.print("Codesigning image '\(destinationURL.path)'...", parsable: options.jsonOutput)
             _ = try Shell.execute(arguments)
         }
 
-        PrettyPrint.print("Deleting temporary directory '\(temporaryURL.path)'...")
+        PrettyPrint.print("Deleting temporary directory '\(temporaryURL.path)'...", parsable: options.jsonOutput)
         try FileManager.default.removeItem(at: temporaryURL)
 
-        PrettyPrint.print("Created image '\(destinationURL.path)'")
+        PrettyPrint.print("Created image '\(destinationURL.path)'", parsable: options.jsonOutput)
     }
 
     /// Generates a macOS Installer Package, optionally codesigning.
@@ -189,7 +189,7 @@ struct Generator {
     /// - Throws: A `MistError` if the macOS Installer Package fails to generate.
     private static func generatePackage(product: Product, options: DownloadOptions) throws {
 
-        PrettyPrint.printHeader("PACKAGE")
+        PrettyPrint.printHeader("PACKAGE",parsable: options.jsonOutput)
 
         if product.isTooBigForPackagePayload {
             try generateBigPackage(product: product, options: options)
@@ -220,34 +220,34 @@ struct Generator {
         var arguments: [String] = ["pkgbuild", "--identifier", identifier, "--install-location", installLocation, "--scripts", scriptsURL.path, "--root", temporaryURL.path, "--version", version]
 
         if FileManager.default.fileExists(atPath: temporaryURL.path) {
-            PrettyPrint.print("Deleting old temporary directory '\(temporaryURL.path)'...")
+            PrettyPrint.print("Deleting old temporary directory '\(temporaryURL.path)'...", parsable: options.jsonOutput)
             try FileManager.default.removeItem(at: temporaryURL)
         }
 
-        PrettyPrint.print("Creating new temporary directory '\(temporaryURL.path)'...")
+        PrettyPrint.print("Creating new temporary directory '\(temporaryURL.path)'...", parsable: options.jsonOutput)
         try FileManager.default.createDirectory(at: temporaryURL, withIntermediateDirectories: true, attributes: nil)
 
-        PrettyPrint.print("Creating ZIP archive '\(zipURL.path)'...")
+        PrettyPrint.print("Creating ZIP archive '\(zipURL.path)'...", parsable: options.jsonOutput)
         _ = try Shell.execute(zipArguments)
 
-        PrettyPrint.print("Splitting ZIP archive '\(zipURL.path)'...")
+        PrettyPrint.print("Splitting ZIP archive '\(zipURL.path)'...", parsable: options.jsonOutput)
         _ = try Shell.execute(splitArguments, currentDirectoryPath: temporaryURL.path)
 
-        PrettyPrint.print("Deleting temporary ZIP archive '\(zipURL.path)'")
+        PrettyPrint.print("Deleting temporary ZIP archive '\(zipURL.path)'", parsable: options.jsonOutput)
         try FileManager.default.removeItem(at: zipURL)
 
         if FileManager.default.fileExists(atPath: scriptsURL.path) {
-            PrettyPrint.print("Deleting old temporary scripts directory '\(scriptsURL.path)'...")
+            PrettyPrint.print("Deleting old temporary scripts directory '\(scriptsURL.path)'...", parsable: options.jsonOutput)
             try FileManager.default.removeItem(at: scriptsURL)
         }
 
-        PrettyPrint.print("Creating new temporary scripts directory '\(scriptsURL.path)'...")
+        PrettyPrint.print("Creating new temporary scripts directory '\(scriptsURL.path)'...", parsable: options.jsonOutput)
         try FileManager.default.createDirectory(at: scriptsURL, withIntermediateDirectories: true, attributes: nil)
 
-        PrettyPrint.print("Creating temporary post install script '\(postInstallURL.path)'...")
+        PrettyPrint.print("Creating temporary post install script '\(postInstallURL.path)'...", parsable: options.jsonOutput)
         try postInstall(for: product).write(to: postInstallURL, atomically: true, encoding: .utf8)
 
-        PrettyPrint.print("Setting executable permissions on temporary post install script '\(postInstallURL.path)'...")
+        PrettyPrint.print("Setting executable permissions on temporary post install script '\(postInstallURL.path)'...", parsable: options.jsonOutput)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: postInstallURL.path)
 
         if let identity: String = options.packageSigningIdentity,
@@ -271,20 +271,20 @@ struct Generator {
         }
 
         if FileManager.default.fileExists(atPath: destinationURL.path) {
-            PrettyPrint.print("Deleting old package '\(destinationURL.path)'...")
+            PrettyPrint.print("Deleting old package '\(destinationURL.path)'...", parsable: options.jsonOutput)
             try FileManager.default.removeItem(at: destinationURL)
         }
 
-        PrettyPrint.print("Creating package '\(destinationURL.path)'...")
+        PrettyPrint.print("Creating package '\(destinationURL.path)'...", parsable: options.jsonOutput)
         _ = try Shell.execute(arguments)
 
-        PrettyPrint.print("Deleting temporary directory '\(temporaryURL.path)'...")
+        PrettyPrint.print("Deleting temporary directory '\(temporaryURL.path)'...", parsable: options.jsonOutput)
         try FileManager.default.removeItem(at: temporaryURL)
 
-        PrettyPrint.print("Deleting temporary scripts directory '\(scriptsURL.path)'...")
+        PrettyPrint.print("Deleting temporary scripts directory '\(scriptsURL.path)'...", parsable: options.jsonOutput)
         try FileManager.default.removeItem(at: scriptsURL)
 
-        PrettyPrint.print("Created package '\(destinationURL.path)'")
+        PrettyPrint.print("Created package '\(destinationURL.path)'", parsable: options.jsonOutput)
     }
 
     /// Generates a macOS Installer Package for payloads smaller than 8GB (ie. **macOS Catalina** and below).
@@ -322,13 +322,13 @@ struct Generator {
         }
 
         if FileManager.default.fileExists(atPath: destinationURL.path) {
-            PrettyPrint.print("Deleting old package '\(destinationURL.path)'...")
+            PrettyPrint.print("Deleting old package '\(destinationURL.path)'...", parsable: options.jsonOutput)
             try FileManager.default.removeItem(at: destinationURL)
         }
 
-        PrettyPrint.print("Creating package '\(destinationURL.path)'...")
+        PrettyPrint.print("Creating package '\(destinationURL.path)'...", parsable: options.jsonOutput)
         _ = try Shell.execute(arguments)
-        PrettyPrint.print("Created package '\(destinationURL.path)'")
+        PrettyPrint.print("Created package '\(destinationURL.path)'", parsable: options.jsonOutput)
     }
 
     /// Creates a custom postinstall script for the macOS Installer Package, used to re-join large payloads (ie. **macOS Big Sur** and above).

--- a/Mist/Helpers/Generator.swift
+++ b/Mist/Helpers/Generator.swift
@@ -30,7 +30,7 @@ struct Generator {
     /// - Throws: A `MistError` if the macOS Firmware fails to generate.
     private static func generateFirmware(firmware: Firmware, options: DownloadOptions) throws {
 
-        PrettyPrint.printHeader("FIRMWARE",parsable: options.jsonOutput)
+        PrettyPrint.printHeader("FIRMWARE",structuredOutput: options.structuredOutput)
         let temporaryURL: URL = URL(fileURLWithPath: options.temporaryDirectory(for: firmware))
 
         guard let firmwareURL: URL = URL(string: firmware.url) else {
@@ -40,7 +40,7 @@ struct Generator {
         let temporaryFirmwareURL: URL = temporaryURL.appendingPathComponent(firmwareURL.lastPathComponent)
         let destinationURL: URL = URL(fileURLWithPath: options.firmwarePath(for: firmware))
 
-        PrettyPrint.print("Validating Shasum matches \(firmware.shasum)...", parsable: options.jsonOutput)
+        PrettyPrint.print("Validating Shasum matches \(firmware.shasum)...", structuredOutput: options.structuredOutput)
 
         guard let string: String = try Shell.execute(["shasum", temporaryFirmwareURL.path]),
             let shasum: String = string.split(separator: " ").map({ String($0) }).first else {
@@ -59,11 +59,11 @@ struct Generator {
         }
 
         if FileManager.default.fileExists(atPath: destinationURL.path) {
-            PrettyPrint.print("Deleting old firmware '\(destinationURL.path)'...", parsable: options.jsonOutput)
+            PrettyPrint.print("Deleting old firmware '\(destinationURL.path)'...", structuredOutput: options.structuredOutput)
             try FileManager.default.removeItem(at: destinationURL)
         }
 
-        PrettyPrint.print("Moving '\(temporaryFirmwareURL.path)' to '\(destinationURL.path)'...", parsable: options.jsonOutput)
+        PrettyPrint.print("Moving '\(temporaryFirmwareURL.path)' to '\(destinationURL.path)'...", structuredOutput: options.structuredOutput)
         try FileManager.default.moveItem(at: temporaryFirmwareURL, to: destinationURL)
     }
 
@@ -98,7 +98,7 @@ struct Generator {
     /// - Throws: A `MistError` if the Application Bundle fails to generate.
     private static func generateApplication(product: Product, options: DownloadOptions) throws {
 
-        PrettyPrint.printHeader("APPLICATION",parsable: options.jsonOutput)
+        PrettyPrint.printHeader("APPLICATION",structuredOutput: options.structuredOutput)
         let destinationURL: URL = URL(fileURLWithPath: options.applicationPath(for: product))
 
         if !options.force {
@@ -109,11 +109,11 @@ struct Generator {
         }
 
         if FileManager.default.fileExists(atPath: destinationURL.path) {
-            PrettyPrint.print("Deleting old application '\(destinationURL.path)'...", parsable: options.jsonOutput)
+            PrettyPrint.print("Deleting old application '\(destinationURL.path)'...", structuredOutput: options.structuredOutput)
             try FileManager.default.removeItem(at: destinationURL)
         }
 
-        PrettyPrint.print("Copying '\(product.installerURL.path)' to '\(destinationURL.path)'...", parsable: options.jsonOutput)
+        PrettyPrint.print("Copying '\(product.installerURL.path)' to '\(destinationURL.path)'...", structuredOutput: options.structuredOutput)
         try FileManager.default.copyItem(at: product.installerURL, to: destinationURL)
     }
 
@@ -126,20 +126,20 @@ struct Generator {
     /// - Throws: A `MistError` if the macOS Installer Disk Image fails to generate.
     private static func generateImage(product: Product, options: DownloadOptions) throws {
 
-        PrettyPrint.printHeader("DISK IMAGE",parsable: options.jsonOutput)
+        PrettyPrint.printHeader("DISK IMAGE",structuredOutput: options.structuredOutput)
         let temporaryURL: URL = URL(fileURLWithPath: options.temporaryDirectory(for: product))
         let temporaryApplicationURL: URL = temporaryURL.appendingPathComponent("Install \(product.name).app")
         let destinationURL: URL = URL(fileURLWithPath: options.imagePath(for: product))
 
         if FileManager.default.fileExists(atPath: temporaryURL.path) {
-            PrettyPrint.print("Deleting old temporary directory '\(temporaryURL.path)'...", parsable: options.jsonOutput)
+            PrettyPrint.print("Deleting old temporary directory '\(temporaryURL.path)'...", structuredOutput: options.structuredOutput)
             try FileManager.default.removeItem(at: temporaryURL)
         }
 
-        PrettyPrint.print("Creating new temporary directory '\(temporaryURL.path)'...", parsable: options.jsonOutput)
+        PrettyPrint.print("Creating new temporary directory '\(temporaryURL.path)'...", structuredOutput: options.structuredOutput)
         try FileManager.default.createDirectory(at: temporaryURL, withIntermediateDirectories: true, attributes: nil)
 
-        PrettyPrint.print("Copying '\(product.installerURL.path)' to '\(temporaryApplicationURL.path)'...", parsable: options.jsonOutput)
+        PrettyPrint.print("Copying '\(product.installerURL.path)' to '\(temporaryApplicationURL.path)'...", structuredOutput: options.structuredOutput)
         try FileManager.default.copyItem(at: product.installerURL, to: temporaryApplicationURL)
 
         if !options.force {
@@ -150,11 +150,11 @@ struct Generator {
         }
 
         if FileManager.default.fileExists(atPath: destinationURL.path) {
-            PrettyPrint.print("Deleting old image '\(destinationURL.path)'...", parsable: options.jsonOutput)
+            PrettyPrint.print("Deleting old image '\(destinationURL.path)'...", structuredOutput: options.structuredOutput)
             try FileManager.default.removeItem(at: destinationURL)
         }
 
-        PrettyPrint.print("Creating image '\(destinationURL.path)'...", parsable: options.jsonOutput)
+        PrettyPrint.print("Creating image '\(destinationURL.path)'...", structuredOutput: options.structuredOutput)
         let arguments: [String] = ["hdiutil", "create", "-fs", "HFS+", "-srcFolder", temporaryURL.path, "-volname", "Install \(product.name)", destinationURL.path]
         _ = try Shell.execute(arguments)
 
@@ -170,14 +170,14 @@ struct Generator {
 
             arguments += [destinationURL.path]
 
-            PrettyPrint.print("Codesigning image '\(destinationURL.path)'...", parsable: options.jsonOutput)
+            PrettyPrint.print("Codesigning image '\(destinationURL.path)'...", structuredOutput: options.structuredOutput)
             _ = try Shell.execute(arguments)
         }
 
-        PrettyPrint.print("Deleting temporary directory '\(temporaryURL.path)'...", parsable: options.jsonOutput)
+        PrettyPrint.print("Deleting temporary directory '\(temporaryURL.path)'...", structuredOutput: options.structuredOutput)
         try FileManager.default.removeItem(at: temporaryURL)
 
-        PrettyPrint.print("Created image '\(destinationURL.path)'", parsable: options.jsonOutput)
+        PrettyPrint.print("Created image '\(destinationURL.path)'", structuredOutput: options.structuredOutput)
     }
 
     /// Generates a macOS Installer Package, optionally codesigning.
@@ -189,7 +189,7 @@ struct Generator {
     /// - Throws: A `MistError` if the macOS Installer Package fails to generate.
     private static func generatePackage(product: Product, options: DownloadOptions) throws {
 
-        PrettyPrint.printHeader("PACKAGE",parsable: options.jsonOutput)
+        PrettyPrint.printHeader("PACKAGE",structuredOutput: options.structuredOutput)
 
         if product.isTooBigForPackagePayload {
             try generateBigPackage(product: product, options: options)
@@ -220,34 +220,34 @@ struct Generator {
         var arguments: [String] = ["pkgbuild", "--identifier", identifier, "--install-location", installLocation, "--scripts", scriptsURL.path, "--root", temporaryURL.path, "--version", version]
 
         if FileManager.default.fileExists(atPath: temporaryURL.path) {
-            PrettyPrint.print("Deleting old temporary directory '\(temporaryURL.path)'...", parsable: options.jsonOutput)
+            PrettyPrint.print("Deleting old temporary directory '\(temporaryURL.path)'...", structuredOutput: options.structuredOutput)
             try FileManager.default.removeItem(at: temporaryURL)
         }
 
-        PrettyPrint.print("Creating new temporary directory '\(temporaryURL.path)'...", parsable: options.jsonOutput)
+        PrettyPrint.print("Creating new temporary directory '\(temporaryURL.path)'...", structuredOutput: options.structuredOutput)
         try FileManager.default.createDirectory(at: temporaryURL, withIntermediateDirectories: true, attributes: nil)
 
-        PrettyPrint.print("Creating ZIP archive '\(zipURL.path)'...", parsable: options.jsonOutput)
+        PrettyPrint.print("Creating ZIP archive '\(zipURL.path)'...", structuredOutput: options.structuredOutput)
         _ = try Shell.execute(zipArguments)
 
-        PrettyPrint.print("Splitting ZIP archive '\(zipURL.path)'...", parsable: options.jsonOutput)
+        PrettyPrint.print("Splitting ZIP archive '\(zipURL.path)'...", structuredOutput: options.structuredOutput)
         _ = try Shell.execute(splitArguments, currentDirectoryPath: temporaryURL.path)
 
-        PrettyPrint.print("Deleting temporary ZIP archive '\(zipURL.path)'", parsable: options.jsonOutput)
+        PrettyPrint.print("Deleting temporary ZIP archive '\(zipURL.path)'", structuredOutput: options.structuredOutput)
         try FileManager.default.removeItem(at: zipURL)
 
         if FileManager.default.fileExists(atPath: scriptsURL.path) {
-            PrettyPrint.print("Deleting old temporary scripts directory '\(scriptsURL.path)'...", parsable: options.jsonOutput)
+            PrettyPrint.print("Deleting old temporary scripts directory '\(scriptsURL.path)'...", structuredOutput: options.structuredOutput)
             try FileManager.default.removeItem(at: scriptsURL)
         }
 
-        PrettyPrint.print("Creating new temporary scripts directory '\(scriptsURL.path)'...", parsable: options.jsonOutput)
+        PrettyPrint.print("Creating new temporary scripts directory '\(scriptsURL.path)'...", structuredOutput: options.structuredOutput)
         try FileManager.default.createDirectory(at: scriptsURL, withIntermediateDirectories: true, attributes: nil)
 
-        PrettyPrint.print("Creating temporary post install script '\(postInstallURL.path)'...", parsable: options.jsonOutput)
+        PrettyPrint.print("Creating temporary post install script '\(postInstallURL.path)'...", structuredOutput: options.structuredOutput)
         try postInstall(for: product).write(to: postInstallURL, atomically: true, encoding: .utf8)
 
-        PrettyPrint.print("Setting executable permissions on temporary post install script '\(postInstallURL.path)'...", parsable: options.jsonOutput)
+        PrettyPrint.print("Setting executable permissions on temporary post install script '\(postInstallURL.path)'...", structuredOutput: options.structuredOutput)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: postInstallURL.path)
 
         if let identity: String = options.packageSigningIdentity,
@@ -271,20 +271,20 @@ struct Generator {
         }
 
         if FileManager.default.fileExists(atPath: destinationURL.path) {
-            PrettyPrint.print("Deleting old package '\(destinationURL.path)'...", parsable: options.jsonOutput)
+            PrettyPrint.print("Deleting old package '\(destinationURL.path)'...", structuredOutput: options.structuredOutput)
             try FileManager.default.removeItem(at: destinationURL)
         }
 
-        PrettyPrint.print("Creating package '\(destinationURL.path)'...", parsable: options.jsonOutput)
+        PrettyPrint.print("Creating package '\(destinationURL.path)'...", structuredOutput: options.structuredOutput)
         _ = try Shell.execute(arguments)
 
-        PrettyPrint.print("Deleting temporary directory '\(temporaryURL.path)'...", parsable: options.jsonOutput)
+        PrettyPrint.print("Deleting temporary directory '\(temporaryURL.path)'...", structuredOutput: options.structuredOutput)
         try FileManager.default.removeItem(at: temporaryURL)
 
-        PrettyPrint.print("Deleting temporary scripts directory '\(scriptsURL.path)'...", parsable: options.jsonOutput)
+        PrettyPrint.print("Deleting temporary scripts directory '\(scriptsURL.path)'...", structuredOutput: options.structuredOutput)
         try FileManager.default.removeItem(at: scriptsURL)
 
-        PrettyPrint.print("Created package '\(destinationURL.path)'", parsable: options.jsonOutput)
+        PrettyPrint.print("Created package '\(destinationURL.path)'", structuredOutput: options.structuredOutput)
     }
 
     /// Generates a macOS Installer Package for payloads smaller than 8GB (ie. **macOS Catalina** and below).
@@ -322,13 +322,13 @@ struct Generator {
         }
 
         if FileManager.default.fileExists(atPath: destinationURL.path) {
-            PrettyPrint.print("Deleting old package '\(destinationURL.path)'...", parsable: options.jsonOutput)
+            PrettyPrint.print("Deleting old package '\(destinationURL.path)'...", structuredOutput: options.structuredOutput)
             try FileManager.default.removeItem(at: destinationURL)
         }
 
-        PrettyPrint.print("Creating package '\(destinationURL.path)'...", parsable: options.jsonOutput)
+        PrettyPrint.print("Creating package '\(destinationURL.path)'...", structuredOutput: options.structuredOutput)
         _ = try Shell.execute(arguments)
-        PrettyPrint.print("Created package '\(destinationURL.path)'", parsable: options.jsonOutput)
+        PrettyPrint.print("Created package '\(destinationURL.path)'", structuredOutput: options.structuredOutput)
     }
 
     /// Creates a custom postinstall script for the macOS Installer Package, used to re-join large payloads (ie. **macOS Big Sur** and above).

--- a/Mist/Helpers/HTTP.swift
+++ b/Mist/Helpers/HTTP.swift
@@ -23,7 +23,7 @@ struct HTTP {
         let firmwaresURLString: String = Firmware.firmwaresURL
 
         guard let firmwaresURL: URL = URL(string: firmwaresURLString) else {
-            !quiet ? PrettyPrint.print("There was an error retrieving firmwares from \(firmwaresURLString)...", parsable: false) : Mist.noop()
+            !quiet ? PrettyPrint.print("There was an error retrieving firmwares from \(firmwaresURLString)...", structuredOutput: false) : Mist.noop()
             return []
         }
 
@@ -33,7 +33,7 @@ struct HTTP {
             guard let data: Data = string.data(using: .utf8),
                 let dictionary: [String: Any] = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any],
                 let devices: [String: Any] = dictionary["devices"] as? [String: Any] else {
-                !quiet ? PrettyPrint.print("There was an error retrieving firmwares from \(firmwaresURLString)...", parsable: false) : Mist.noop()
+                !quiet ? PrettyPrint.print("There was an error retrieving firmwares from \(firmwaresURLString)...", structuredOutput: false) : Mist.noop()
                 return []
             }
 
@@ -55,7 +55,7 @@ struct HTTP {
                 }
             }
         } catch {
-            !quiet ? PrettyPrint.print(error.localizedDescription, parsable: false) : Mist.noop()
+            !quiet ? PrettyPrint.print(error.localizedDescription, structuredOutput: false) : Mist.noop()
         }
 
         if !includeBetas {
@@ -110,7 +110,7 @@ struct HTTP {
         for catalogURL in catalogURLs {
 
             guard let url: URL = URL(string: catalogURL) else {
-                !quiet ? PrettyPrint.print("There was an error retrieving the catalog from \(catalogURL), skipping...", parsable: false) : Mist.noop()
+                !quiet ? PrettyPrint.print("There was an error retrieving the catalog from \(catalogURL), skipping...", structuredOutput: false) : Mist.noop()
                 continue
             }
 
@@ -118,7 +118,7 @@ struct HTTP {
                 let string: String = try String(contentsOf: url, encoding: .utf8)
 
                 guard let data: Data = string.data(using: .utf8) else {
-                    !quiet ? PrettyPrint.print("Unable to get data from catalog, skipping...", parsable: false) : Mist.noop()
+                    !quiet ? PrettyPrint.print("Unable to get data from catalog, skipping...", structuredOutput: false) : Mist.noop()
                     continue
                 }
 
@@ -126,13 +126,13 @@ struct HTTP {
 
                 guard let catalog: [String: Any] = try PropertyListSerialization.propertyList(from: data, options: [.mutableContainers], format: &format) as? [String: Any],
                     let productsDictionary: [String: Any] = catalog["Products"] as? [String: Any] else {
-                    !quiet ? PrettyPrint.print("Unable to get 'Products' dictionary from catalog, skipping...", parsable: false) : Mist.noop()
+                    !quiet ? PrettyPrint.print("Unable to get 'Products' dictionary from catalog, skipping...", structuredOutput: false) : Mist.noop()
                     continue
                 }
 
                 products.append(contentsOf: getProducts(from: productsDictionary, quiet: quiet).filter { !products.map { $0.identifier }.contains($0.identifier) })
             } catch {
-                !quiet ? PrettyPrint.print(error.localizedDescription, parsable: false) : Mist.noop()
+                !quiet ? PrettyPrint.print(error.localizedDescription, structuredOutput: false) : Mist.noop()
             }
         }
 
@@ -170,7 +170,7 @@ struct HTTP {
             guard let distributions: [String: Any] = value["Distributions"] as? [String: Any],
                 let distributionURL: String = distributions["English"] as? String,
                 let url: URL = URL(string: distributionURL) else {
-                !quiet ? PrettyPrint.print("No English distribution found, skipping...", parsable: false) : Mist.noop()
+                !quiet ? PrettyPrint.print("No English distribution found, skipping...", structuredOutput: false) : Mist.noop()
                 continue
             }
 
@@ -182,7 +182,7 @@ struct HTTP {
                     let name: String = distribution["NAME"] as? String,
                     let version: String = distribution["VERSION"] as? String,
                     let build: String = distribution["BUILD"] as? String else {
-                    !quiet ? PrettyPrint.print("No 'Name', 'Version' or 'Build' found, skipping...", parsable: false) : Mist.noop()
+                    !quiet ? PrettyPrint.print("No 'Name', 'Version' or 'Build' found, skipping...", structuredOutput: false) : Mist.noop()
                     continue
                 }
 
@@ -200,7 +200,7 @@ struct HTTP {
                 let product: Product = try JSONDecoder().decode(Product.self, from: productData)
                 products.append(product)
             } catch {
-                !quiet ? PrettyPrint.print(error.localizedDescription, parsable: false) : Mist.noop()
+                !quiet ? PrettyPrint.print(error.localizedDescription, structuredOutput: false) : Mist.noop()
             }
         }
 

--- a/Mist/Helpers/HTTP.swift
+++ b/Mist/Helpers/HTTP.swift
@@ -23,7 +23,7 @@ struct HTTP {
         let firmwaresURLString: String = Firmware.firmwaresURL
 
         guard let firmwaresURL: URL = URL(string: firmwaresURLString) else {
-            !quiet ? PrettyPrint.print("There was an error retrieving firmwares from \(firmwaresURLString)...") : Mist.noop()
+            !quiet ? PrettyPrint.print("There was an error retrieving firmwares from \(firmwaresURLString)...", parsable: false) : Mist.noop()
             return []
         }
 
@@ -33,7 +33,7 @@ struct HTTP {
             guard let data: Data = string.data(using: .utf8),
                 let dictionary: [String: Any] = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any],
                 let devices: [String: Any] = dictionary["devices"] as? [String: Any] else {
-                !quiet ? PrettyPrint.print("There was an error retrieving firmwares from \(firmwaresURLString)...") : Mist.noop()
+                !quiet ? PrettyPrint.print("There was an error retrieving firmwares from \(firmwaresURLString)...", parsable: false) : Mist.noop()
                 return []
             }
 
@@ -55,7 +55,7 @@ struct HTTP {
                 }
             }
         } catch {
-            !quiet ? PrettyPrint.print(error.localizedDescription) : Mist.noop()
+            !quiet ? PrettyPrint.print(error.localizedDescription, parsable: false) : Mist.noop()
         }
 
         if !includeBetas {
@@ -110,7 +110,7 @@ struct HTTP {
         for catalogURL in catalogURLs {
 
             guard let url: URL = URL(string: catalogURL) else {
-                !quiet ? PrettyPrint.print("There was an error retrieving the catalog from \(catalogURL), skipping...") : Mist.noop()
+                !quiet ? PrettyPrint.print("There was an error retrieving the catalog from \(catalogURL), skipping...", parsable: false) : Mist.noop()
                 continue
             }
 
@@ -118,7 +118,7 @@ struct HTTP {
                 let string: String = try String(contentsOf: url, encoding: .utf8)
 
                 guard let data: Data = string.data(using: .utf8) else {
-                    !quiet ? PrettyPrint.print("Unable to get data from catalog, skipping...") : Mist.noop()
+                    !quiet ? PrettyPrint.print("Unable to get data from catalog, skipping...", parsable: false) : Mist.noop()
                     continue
                 }
 
@@ -126,13 +126,13 @@ struct HTTP {
 
                 guard let catalog: [String: Any] = try PropertyListSerialization.propertyList(from: data, options: [.mutableContainers], format: &format) as? [String: Any],
                     let productsDictionary: [String: Any] = catalog["Products"] as? [String: Any] else {
-                    !quiet ? PrettyPrint.print("Unable to get 'Products' dictionary from catalog, skipping...") : Mist.noop()
+                    !quiet ? PrettyPrint.print("Unable to get 'Products' dictionary from catalog, skipping...", parsable: false) : Mist.noop()
                     continue
                 }
 
                 products.append(contentsOf: getProducts(from: productsDictionary, quiet: quiet).filter { !products.map { $0.identifier }.contains($0.identifier) })
             } catch {
-                !quiet ? PrettyPrint.print(error.localizedDescription) : Mist.noop()
+                !quiet ? PrettyPrint.print(error.localizedDescription, parsable: false) : Mist.noop()
             }
         }
 
@@ -170,7 +170,7 @@ struct HTTP {
             guard let distributions: [String: Any] = value["Distributions"] as? [String: Any],
                 let distributionURL: String = distributions["English"] as? String,
                 let url: URL = URL(string: distributionURL) else {
-                !quiet ? PrettyPrint.print("No English distribution found, skipping...") : Mist.noop()
+                !quiet ? PrettyPrint.print("No English distribution found, skipping...", parsable: false) : Mist.noop()
                 continue
             }
 
@@ -182,7 +182,7 @@ struct HTTP {
                     let name: String = distribution["NAME"] as? String,
                     let version: String = distribution["VERSION"] as? String,
                     let build: String = distribution["BUILD"] as? String else {
-                    !quiet ? PrettyPrint.print("No 'Name', 'Version' or 'Build' found, skipping...") : Mist.noop()
+                    !quiet ? PrettyPrint.print("No 'Name', 'Version' or 'Build' found, skipping...", parsable: false) : Mist.noop()
                     continue
                 }
 
@@ -200,7 +200,7 @@ struct HTTP {
                 let product: Product = try JSONDecoder().decode(Product.self, from: productData)
                 products.append(product)
             } catch {
-                !quiet ? PrettyPrint.print(error.localizedDescription) : Mist.noop()
+                !quiet ? PrettyPrint.print(error.localizedDescription, parsable: false) : Mist.noop()
             }
         }
 

--- a/Mist/Helpers/Installer.swift
+++ b/Mist/Helpers/Installer.swift
@@ -26,19 +26,19 @@ struct Installer {
         let temporaryURL: URL = URL(fileURLWithPath: options.temporaryDirectory(for: product))
         let distributionURL: URL = temporaryURL.appendingPathComponent(url.lastPathComponent)
 
-        PrettyPrint.printHeader("INSTALL",parsable: options.jsonOutput)
+        PrettyPrint.printHeader("INSTALL",structuredOutput: options.structuredOutput)
 
         if FileManager.default.fileExists(atPath: product.installerURL.path) {
-            PrettyPrint.print("Deleting old installer '\(product.installerURL.path)'...", parsable: options.jsonOutput)
+            PrettyPrint.print("Deleting old installer '\(product.installerURL.path)'...", structuredOutput: options.structuredOutput)
             try FileManager.default.removeItem(at: product.installerURL)
         }
 
-        PrettyPrint.print("Creating new installer '\(product.installerURL.path)'...", parsable: options.jsonOutput)
+        PrettyPrint.print("Creating new installer '\(product.installerURL.path)'...", structuredOutput: options.structuredOutput)
         let arguments: [String] = ["installer", "-pkg", distributionURL.path, "-target", "/"]
         let variables: [String: String] = ["CM_BUILD": "CM_BUILD"]
         _ = try Shell.execute(arguments, environment: variables)
-        PrettyPrint.print("Deleting temporary directory '\(temporaryURL.path)'...", parsable: options.jsonOutput)
+        PrettyPrint.print("Deleting temporary directory '\(temporaryURL.path)'...", structuredOutput: options.structuredOutput)
         try FileManager.default.removeItem(at: temporaryURL)
-        PrettyPrint.print("Created new installer '\(product.installerURL.path)'", parsable: options.jsonOutput)
+        PrettyPrint.print("Created new installer '\(product.installerURL.path)'", structuredOutput: options.structuredOutput)
     }
 }

--- a/Mist/Helpers/Installer.swift
+++ b/Mist/Helpers/Installer.swift
@@ -26,19 +26,19 @@ struct Installer {
         let temporaryURL: URL = URL(fileURLWithPath: options.temporaryDirectory(for: product))
         let distributionURL: URL = temporaryURL.appendingPathComponent(url.lastPathComponent)
 
-        PrettyPrint.printHeader("INSTALL")
+        PrettyPrint.printHeader("INSTALL",parsable: options.jsonOutput)
 
         if FileManager.default.fileExists(atPath: product.installerURL.path) {
-            PrettyPrint.print("Deleting old installer '\(product.installerURL.path)'...")
+            PrettyPrint.print("Deleting old installer '\(product.installerURL.path)'...", parsable: options.jsonOutput)
             try FileManager.default.removeItem(at: product.installerURL)
         }
 
-        PrettyPrint.print("Creating new installer '\(product.installerURL.path)'...")
+        PrettyPrint.print("Creating new installer '\(product.installerURL.path)'...", parsable: options.jsonOutput)
         let arguments: [String] = ["installer", "-pkg", distributionURL.path, "-target", "/"]
         let variables: [String: String] = ["CM_BUILD": "CM_BUILD"]
         _ = try Shell.execute(arguments, environment: variables)
-        PrettyPrint.print("Deleting temporary directory '\(temporaryURL.path)'...")
+        PrettyPrint.print("Deleting temporary directory '\(temporaryURL.path)'...", parsable: options.jsonOutput)
         try FileManager.default.removeItem(at: temporaryURL)
-        PrettyPrint.print("Created new installer '\(product.installerURL.path)'")
+        PrettyPrint.print("Created new installer '\(product.installerURL.path)'", parsable: options.jsonOutput)
     }
 }

--- a/Mist/Helpers/PrettyPrint.swift
+++ b/Mist/Helpers/PrettyPrint.swift
@@ -19,12 +19,12 @@ struct PrettyPrint {
     ///
     /// - Parameters:
     ///   - header: The string to print.
-    static func printHeader(_ header: String, parsable:Bool) {
+    static func printHeader(_ header: String, structuredOutput:Bool) {
         let stderr = FileHandle.standardError
         var string:String = ""
 
 
-        if (parsable==false) {
+        if (structuredOutput==false) {
             let horizontal: String = String(repeating: "─", count: header.count + 2)
             string = "┌\(horizontal)┐\n│ \(header) │\n└\(horizontal)┘"
 
@@ -54,11 +54,11 @@ struct PrettyPrint {
     ///   - prefix:      The optional prefix.
     ///   - prefixColor: The optional prefix color.
     ///   - replacing:   Optionally set to `true` to replace the previous line.
-    static func print(_ stringToPrint: String, prefix: Prefix = .default, prefixColor: String.Color = .green, replacing: Bool = false, parsable: Bool, messagetype:String = "Info", messageObject:Dictionary<String, Any> = [:]) {
+    static func print(_ stringToPrint: String, prefix: Prefix = .default, prefixColor: String.Color = .green, replacing: Bool = false, structuredOutput: Bool, messagetype:String = "Info", messageObject:Dictionary<String, Any> = [:]) {
         let stderr = FileHandle.standardError
         var string:String = ""
 
-        if (parsable==false) {
+        if (structuredOutput==false) {
             let replacing: String = replacing ? "\u{1B}[1A\u{1B}[K" : ""
             string = "\(replacing)\(prefix.rawValue.color(prefixColor))\(stringToPrint)"
 

--- a/Mist/Model/DownloadInfo.swift
+++ b/Mist/Model/DownloadInfo.swift
@@ -1,0 +1,64 @@
+//
+//  Product.swift
+//  Mist
+//
+//  Created by Nindi Gill on 10/3/21.
+//
+
+import Foundation
+
+struct DownloadInfo: Decodable {
+
+    enum CodingKeys: String, CodingKey {
+        case identifier = "Identifier"
+        case name = "Name"
+        case version = "Version"
+        case build = "Build"
+        case date = "PostDate"
+        case distribution = "DistributionURL"
+        case packages = "Packages"
+    }
+
+    let identifier: String
+    let name: String
+    let version: String
+    let build: String
+    let date: String
+    let distribution: String
+    let packages: [Package]
+
+    var totalFiles: Int {
+        packages.count + 1
+    }
+    var dictionary: [String: Any] {
+        [
+            "identifier": identifier,
+            "name": name,
+            "version": version,
+            "build": build,
+            "size": size,
+            "date": date
+        ]
+    }
+    var size: Int64 {
+        Int64(packages.map { $0.size }.reduce(0, +))
+    }
+    init(from firmware: Firmware) throws {
+        self.identifier=firmware.identifier
+        self.name=firmware.name
+        self.version=firmware.version
+        self.build=firmware.build
+        self.date=firmware.date
+        self.distribution=""
+        self.packages=[]
+    }
+    init(from product: Product) throws {
+        self.identifier=product.identifier
+        self.name=product.name
+        self.version=product.version
+        self.build=product.build
+        self.date=product.date
+        self.distribution=product.distribution
+        self.packages=product.packages
+    }
+}


### PR DESCRIPTION
I incorporated Mist into MDS and it has been working great! I wanted to have a more structured output for easy parsing from MDS so I added in some changes:

1. When Mist exited with an error, it exited as termination status 0. Changed to -1.
2. Add a new option ("-j") for mist download that outputs as messages that are structured JSON data, one per line for easy parsing. There are 3 message types: Header, Info and Progress. Header and info are just KVP with Header/Info as they key and the message as the value. The Progress message has "Progress" as the key and a json hash with the download progress (steps, data completed, etc).
3. Added a new option for PrettyPrint for tell it if it should be structured data or not to output. This required a bunch of changes to every call that I wanted to output as structured. There may have a less intrusive way but this way works. Let me know if you have any ideas on how to make this better.
4. renamed current -> currentBytes, total->totalBytes to make them more clear. Current was being used both as a local variable for index and for the bytes which hurt my brain.
5. Fixed an issue where output was showing bytes remaining and completed as the end of the prior step.
6. Message output that didn't contain data now goes to stderr. For example, all the header and info messages are stderr, but when the plist / json output for mist list is run, it goes to stdout. this makes knowing what data to use when more deterministic.
7. The "Firmware" and "Product" objects shared many similar traits so i created a DownloadInfo struct to pass to Downloader. It probably would have been better to make this a superclass or firmware and product, but that that would have required more structural changes. Let me know if you'd rather go this route.
