### PR TITLE
Disable stdout stream buffering for more immediate output

### DIFF
--- a/Mist/main.swift
+++ b/Mist/main.swift
@@ -7,5 +7,8 @@
 
 import Foundation
 
+//  Disable stdout stream buffering for more immediate output.
+setbuf(__stdoutp, nil)
+
 Mist.main()
 exit(0)

--- a/Mist/main.swift
+++ b/Mist/main.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-//  Disable stdout stream buffering for more immediate output.
+// Disable stdout stream buffering for more immediate output.
 setbuf(__stdoutp, nil)
 
 Mist.main()


### PR DESCRIPTION
After more testing, it turns out this is still helping with running with GitLab CI and a gitlab-runner (See #93).