### PR TITLE
Add  nobrowse option to hdiutil command to stop disk images appearing on desktop

### DIFF
--- a/Mist/Helpers/Generator.swift
+++ b/Mist/Helpers/Generator.swift
@@ -208,7 +208,7 @@ struct Generator {
         _ = try Shell.execute(arguments)
 
         !options.quiet ? PrettyPrint.print("Mounting disk image at mount point '\(product.temporaryISOMountPointURL.path)'...", noAnsi: options.noAnsi) : Mist.noop()
-        arguments = ["hdiutil", "attach", dmgURL.path, "-noverify", "-mountpoint", product.temporaryISOMountPointURL    .path]
+        arguments = ["hdiutil", "attach", dmgURL.path, "-noverify", "-nobrowse", "-mountpoint", product.temporaryISOMountPointURL    .path]
         _ = try Shell.execute(arguments)
 
         !options.quiet ? PrettyPrint.print("Creating install media at mount point '\(product.temporaryISOMountPointURL.path)'...", noAnsi: options.noAnsi) : Mist.noop()

--- a/Mist/Helpers/Installer.swift
+++ b/Mist/Helpers/Installer.swift
@@ -39,7 +39,7 @@ struct Installer {
         _ = try Shell.execute(arguments)
 
         !options.quiet ? PrettyPrint.print("Mounting disk image at mount point '\(product.temporaryDiskImageMountPointURL.path)'...", noAnsi: options.noAnsi) : Mist.noop()
-        arguments = ["hdiutil", "attach", imageURL.path, "-noverify", "-mountpoint", product.temporaryDiskImageMountPointURL.path]
+        arguments = ["hdiutil", "attach", imageURL.path, "-noverify", "-nobrowse", "-mountpoint", product.temporaryDiskImageMountPointURL.path]
         _ = try Shell.execute(arguments)
 
         !options.quiet ? PrettyPrint.print("Creating new installer '\(product.temporaryInstallerURL.path)'...", noAnsi: options.noAnsi) : Mist.noop()


### PR DESCRIPTION
Adding nobrowse option to hdiutil command as per [this feature request](https://github.com/ninxsoft/mist-cli/issues/125#issue-1654872964).