### PR TITLE
Exit 1 for all errors

### DIFF
--- a/Mist/Commands/Download/DownloadFirmwareCommand.swift
+++ b/Mist/Commands/Download/DownloadFirmwareCommand.swift
@@ -334,7 +334,7 @@ struct DownloadFirmwareCommand: ParsableCommand {
         return url
     }
 
-    mutating func run() {
+    mutating func run() throws {
         do {
             try DownloadFirmwareCommand.run(options: options)
         } catch {
@@ -343,6 +343,8 @@ struct DownloadFirmwareCommand: ParsableCommand {
             } else {
                 PrettyPrint.print(error.localizedDescription, noAnsi: options.noAnsi, prefix: .ending, prefixColor: .red)
             }
+
+            throw ExitCode(1)
         }
     }
 }

--- a/Mist/Commands/Download/DownloadInstallerCommand.swift
+++ b/Mist/Commands/Download/DownloadInstallerCommand.swift
@@ -584,7 +584,7 @@ struct DownloadInstallerCommand: ParsableCommand {
         return url
     }
 
-    mutating func run() {
+    mutating func run() throws {
         do {
             try DownloadInstallerCommand.run(options: options)
         } catch {
@@ -593,6 +593,8 @@ struct DownloadInstallerCommand: ParsableCommand {
             } else {
                 PrettyPrint.print(error.localizedDescription, noAnsi: options.noAnsi, prefix: .ending, prefixColor: .red)
             }
+
+            throw ExitCode(1)
         }
     }
 }

--- a/Mist/Commands/List/ListFirmwareCommand.swift
+++ b/Mist/Commands/List/ListFirmwareCommand.swift
@@ -164,7 +164,7 @@ struct ListFirmwareCommand: ParsableCommand {
         }
     }
 
-    mutating func run() {
+    mutating func run() throws {
         do {
             try ListFirmwareCommand.run(options: options)
         } catch {
@@ -173,6 +173,8 @@ struct ListFirmwareCommand: ParsableCommand {
             } else {
                 PrettyPrint.print(error.localizedDescription, noAnsi: options.noAnsi, prefix: .ending, prefixColor: .red)
             }
+
+            throw ExitCode(1)
         }
     }
 }

--- a/Mist/Commands/List/ListInstallerCommand.swift
+++ b/Mist/Commands/List/ListInstallerCommand.swift
@@ -159,7 +159,7 @@ struct ListInstallerCommand: ParsableCommand {
         }
     }
 
-    mutating func run() {
+    mutating func run() throws {
         do {
             try ListInstallerCommand.run(options: options)
         } catch {
@@ -168,6 +168,8 @@ struct ListInstallerCommand: ParsableCommand {
             } else {
                 PrettyPrint.print(error.localizedDescription, noAnsi: options.noAnsi, prefix: .ending, prefixColor: .red)
             }
+
+            throw ExitCode(1)
         }
     }
 }


### PR DESCRIPTION
Fixes #156, returning `1` for all `mist-cli` errors.