### PR TITLE
Only check for new Mist version if verbose output is not suppressed

### DIFF
--- a/Mist/Commands/Download/DownloadFirmwareCommand.swift
+++ b/Mist/Commands/Download/DownloadFirmwareCommand.swift
@@ -26,7 +26,7 @@ struct DownloadFirmwareCommand: ParsableCommand {
     ///
     /// - Throws: A `MistError` if a macOS version fails to download.
     static func run(options: DownloadFirmwareOptions) throws {
-        Mist.checkForNewVersion(noAnsi: options.noAnsi)
+        !options.quiet ? Mist.checkForNewVersion(noAnsi: options.noAnsi) : Mist.noop()
         try inputValidation(options)
         !options.quiet ? PrettyPrint.printHeader("SEARCH", noAnsi: options.noAnsi) : Mist.noop()
         !options.quiet ? PrettyPrint.print("Searching for macOS download '\(options.searchString)'...", noAnsi: options.noAnsi) : Mist.noop()

--- a/Mist/Commands/Download/DownloadInstallerCommand.swift
+++ b/Mist/Commands/Download/DownloadInstallerCommand.swift
@@ -30,7 +30,7 @@ struct DownloadInstallerCommand: ParsableCommand {
     ///
     /// - Throws: A `MistError` if a macOS version fails to download.
     static func run(options: DownloadInstallerOptions) throws {
-        Mist.checkForNewVersion(noAnsi: options.noAnsi)
+        !options.quiet ? Mist.checkForNewVersion(noAnsi: options.noAnsi) : Mist.noop()
         try inputValidation(options)
         !options.quiet ? PrettyPrint.printHeader("SEARCH", noAnsi: options.noAnsi) : Mist.noop()
         !options.quiet ? PrettyPrint.print("Searching for macOS download '\(options.searchString)'...", noAnsi: options.noAnsi) : Mist.noop()

--- a/Mist/Commands/List/ListFirmwareCommand.swift
+++ b/Mist/Commands/List/ListFirmwareCommand.swift
@@ -27,7 +27,7 @@ struct ListFirmwareCommand: ParsableCommand {
     ///
     /// - Throws: A `MistError` if macOS versions fail to be retrieved or exported.
     static func run(options: ListFirmwareOptions) throws {
-        Mist.checkForNewVersion(noAnsi: options.noAnsi)
+        !options.quiet ? Mist.checkForNewVersion(noAnsi: options.noAnsi) : Mist.noop()
         try inputValidation(options)
         !options.quiet ? PrettyPrint.printHeader("SEARCH", noAnsi: options.noAnsi) : Mist.noop()
         !options.quiet ? PrettyPrint.print("Searching for macOS Firmware versions...", noAnsi: options.noAnsi) : Mist.noop()

--- a/Mist/Commands/List/ListInstallerCommand.swift
+++ b/Mist/Commands/List/ListInstallerCommand.swift
@@ -27,7 +27,7 @@ struct ListInstallerCommand: ParsableCommand {
     ///
     /// - Throws: A `MistError` if macOS versions fail to be retrieved or exported.
     static func run(options: ListInstallerOptions) throws {
-        Mist.checkForNewVersion(noAnsi: options.noAnsi)
+        !options.quiet ? Mist.checkForNewVersion(noAnsi: options.noAnsi) : Mist.noop()
         try inputValidation(options)
         !options.quiet ? PrettyPrint.printHeader("SEARCH", noAnsi: options.noAnsi) : Mist.noop()
         !options.quiet ? PrettyPrint.print("Searching for macOS Installer versions...", noAnsi: options.noAnsi) : Mist.noop()


### PR DESCRIPTION
Fixes #169