### PR TITLE
Merge nindi/bugfix-legacy-installers to fix legacy installer tasks

### DIFF
--- a/Mist/Helpers/Generator.swift
+++ b/Mist/Helpers/Generator.swift
@@ -404,7 +404,7 @@ enum Generator {
             arguments = ["\(installer.temporaryInstallerWithAdHocCodeSignaturesURL.path)/Contents/Resources/createinstallmedia"]
         }
 
-        arguments += ["--volume", installer.temporaryISOMountPointURL.path, "--nointeraction"]
+        arguments += ["--volume", volume, "--nointeraction"]
 
         if installer.sierraOrOlder {
             arguments += ["--applicationpath", installer.temporaryInstallerURL.path]

--- a/Mist/Helpers/Generator.swift
+++ b/Mist/Helpers/Generator.swift
@@ -391,6 +391,11 @@ enum Generator {
         var arguments: [String] = ["\(installer.temporaryInstallerURL.path)/Contents/Resources/createinstallmedia"]
 
         if !installer.bigSurOrNewer {
+
+            if FileManager.default.fileExists(atPath: installer.temporaryInstallerWithAdHocCodeSignaturesURL.path) {
+                try FileManager.default.removeItem(at: installer.temporaryInstallerWithAdHocCodeSignaturesURL)
+            }
+
             // swiftlint:disable:next line_length
             !options.quiet ? PrettyPrint.print("Copying '\(installer.temporaryInstallerURL.path)' to '\(installer.temporaryInstallerWithAdHocCodeSignaturesURL.path)'...", noAnsi: options.noAnsi) : Mist.noop()
             try FileManager.default.copyItem(at: installer.temporaryInstallerURL, to: installer.temporaryInstallerWithAdHocCodeSignaturesURL)

--- a/Mist/Helpers/InstallerCreator.swift
+++ b/Mist/Helpers/InstallerCreator.swift
@@ -67,6 +67,13 @@ enum InstallerCreator {
             _ = try Shell.execute(arguments, environment: variables)
         }
 
+        if installer.highSierraOrNewer, !installer.bigSurOrNewer {
+            arguments = ["ditto", "/Applications/Install \(installer.name).app", "\(installer.temporaryDiskImageMountPointURL.path)/Applications/Install \(installer.name).app"]
+            _ = try Shell.execute(arguments)
+            arguments = ["rm", "-r", "/Applications/Install \(installer.name).app"]
+            _ = try Shell.execute(arguments)
+        }
+
         if installer.catalinaOrNewer {
             arguments = ["ditto", "\(installer.temporaryDiskImageMountPointURL.path)Applications", "\(installer.temporaryDiskImageMountPointURL.path)/Applications"]
             _ = try Shell.execute(arguments)

--- a/Mist/Model/Installer.swift
+++ b/Mist/Model/Installer.swift
@@ -610,6 +610,10 @@ struct Installer: Decodable {
         version.range(of: "^10\\.([7-9]|1[0-2])\\.", options: .regularExpression) != nil
     }
 
+    var highSierraOrNewer: Bool {
+        bigSurOrNewer || version.range(of: "^10\\.1[3-5]\\.", options: .regularExpression) != nil
+    }
+
     var catalinaOrNewer: Bool {
         bigSurOrNewer || version.range(of: "^10\\.15\\.", options: .regularExpression) != nil
     }


### PR DESCRIPTION
This PR resolves https://github.com/ninxsoft/mist-cli/issues/194 by merging the bug fixes for legacy installers created by @ninxsoft in [nindi/bugfix-legacy-installers](https://github.com/ninxsoft/mist-cli/tree/nindi/bugfix-legacy-installers). It appears these fixes were simply never merged.

I tested the bootable USB functionality using macOS Sierra, and everything seems to work as intended.